### PR TITLE
bump punycode to 1.4.1 for browser support

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   },
   "dependencies": {
     "lodash.includes": "^4.3.0",
-    "punycode": "^2.0.0"
+    "punycode": "1.4.1"
   },
   "directories": {
     "test": "test"


### PR DESCRIPTION
All test pass via `npm test`
This fixes #7 