### PR TITLE
add .eco TLD

### DIFF
--- a/src/Domains.js
+++ b/src/Domains.js
@@ -315,6 +315,7 @@ export const genericTlds = [
 	"dvag", // dvag Deutsche Vermögensberatung Aktiengesellschaft DVAG
 	"earth", // earth Interlink Co., Ltd.
 	"eat", // eat Charleston Road Registry Inc.
+	"eco", // eco Big Room Inc.
 	"edeka", // edeka EDEKA Verband kaufmännischer Genossenschaften e.V.
 	"edu", // edu EDUCAUSE
 	"education", // education Brice Way, LLC


### PR DESCRIPTION
Please add support for the .eco TLD. We have .eco registrants who would like to use Wix but can't.