### PR TITLE
Add types for exported classes

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,25 @@
+// Type definitions for commons-validator-js 1.0
+// Project: https://github.com/wix/commons-validator-js
+// Definitions by: Robert Mruczek <https://github.com/rtmruczek>
+
+export class EmailValidator {
+  /**
+   * @param allowLocal   Should local addresses be considered valid? default = false
+   * @param allowTld     Should TLDs be allowed? default = false
+   */
+  constructor({allowLocal, allowTld}?: {allowLocal: boolean, allowTld: boolean});
+  isValid: (email: string) => boolean;
+}
+
+export class DomainValidator {
+  /**
+   * @param allowLocal   Should local addresses be considered valid? default = false
+   */
+  constructor({allowLocal}?: {allowLocal: boolean});
+  isValidCountryCodeTld: (ccTld: string) => boolean;
+  isValidGenericTld: (gTld: string) => boolean;
+  isValidInfrastructureTld: (iTld: string) => boolean;
+  isValidTld: (tld: string) => boolean;
+  extractTld: (domain: string) => string | null;
+  isValid: (domain: string) => boolean;
+}

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "lodash.includes": "^4.3.0",
     "punycode": "^1.4.1"
   },
+  "types": "index.d.ts",
   "directories": {
     "test": "test"
   }

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "lodash.includes": "^4.3.0",
     "punycode": "^1.4.1"
   },
-  "types": "index.d.ts",
+  "types": "src/index.d.ts",
   "directories": {
     "test": "test"
   }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,0 +1,25 @@
+// Type definitions for commons-validator-js 1.0
+// Project: https://github.com/wix/commons-validator-js
+// Definitions by: Robert Mruczek <https://github.com/rtmruczek>
+
+export class EmailValidator {
+  /**
+   * @param allowLocal   Should local addresses be considered valid? default = false
+   * @param allowTld     Should TLDs be allowed? default = false
+   */
+  constructor({allowLocal, allowTld}?: {allowLocal: boolean, allowTld: boolean});
+  isValid: (email: string) => boolean;
+}
+
+export class DomainValidator {
+  /**
+   * @param allowLocal   Should local addresses be considered valid? default = false
+   */
+  constructor({allowLocal}?: {allowLocal: boolean});
+  isValidCountryCodeTld: (ccTld: string) => boolean;
+  isValidGenericTld: (gTld: string) => boolean;
+  isValidInfrastructureTld: (iTld: string) => boolean;
+  isValidTld: (tld: string) => boolean;
+  extractTld: (domain: string) => string | null;
+  isValid: (domain: string) => boolean;
+}


### PR DESCRIPTION
Hi, I'd like to use `commons-validator-js` at work, but we use typescript and there are no definitions for this package. This is a simple PR that adds typescript definitions.